### PR TITLE
CQLPG-6: Replace regexp by LIKE for <> and ==

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+## 1.3.0 unpublished
+ * CQLPG-6: Replace regexp by LIKE for <> and ==
 ## 1.2.1 2017-11-14
  * Replace CASE jsonb_typeof(field) ... by an AND/OR expression (CQLPG-8)
  * For numeric values use -> not ->> to make use of the index. (CQLPG-7 partially)

--- a/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -656,7 +656,7 @@ public class CQL2PgJSON {
   }
 
   /**
-   * Returns a numeric match like ">=17" if the node term is a JSON number, null otherwise.
+   * Returns a numeric match like >='"17"' if the node term is a JSON number, null otherwise.
    * @param node  the node to get the comparator operator and the term from
    * @return  the comparison or null
    * @throws CQLFeatureUnsupportedException if cql query attempts to use unsupported operators.
@@ -681,7 +681,7 @@ public class CQL2PgJSON {
       throw new CQLFeatureUnsupportedException("Relation " + node.getRelation().getBase()
           + " not implemented yet: " + node.toString());
     }
-    return comparator + node.getTerm();
+    return comparator + "'\"" +  node.getTerm() + "\"'";
   }
 
   /**
@@ -713,6 +713,20 @@ public class CQL2PgJSON {
   }
 
   /**
+   * Append all strings to the stringBuilder.
+   * <p>
+   * append(sb, "abc", "123") is more easy to read than
+   * sb.append("abc").append("123).
+   * @param stringBuilder where to append
+   * @param strings what to append
+   */
+  private void append(StringBuilder stringBuilder, String ... strings) {
+    for (String string : strings) {
+      stringBuilder.append(string);
+    }
+  }
+
+  /**
    * Create an SQL expression where index is applied to all matches.
    * @param index  index to use
    * @param matches  list of match expressions
@@ -720,6 +734,7 @@ public class CQL2PgJSON {
    * @return SQL expression
    * @throws QueryValidationException
    */
+  @SuppressWarnings("squid:S1192")  // suppress "String literals should not be duplicated"
   private String index2sql(String index, String [] matches, String numberMatch) throws QueryValidationException {
     StringBuilder s = new StringBuilder();
     for (String match : matches) {
@@ -744,7 +759,7 @@ public class CQL2PgJSON {
         // numberMatch: Both sides of the comparison operator are JSONB expressions.
 
         // When comparing two JSONBs a JSONB containing any string is bigger than
-        // any JSONB containging any number.
+        // any JSONB containing any number.
         // Therefore we need to check the jsonb_typeof, which is supported by a
         // ((jsonb->'amount')) index.
 
@@ -752,10 +767,14 @@ public class CQL2PgJSON {
          *  OR ( jsonb_typeof(jsonb->'amount')<>'numeric' AND jsonb->'amount' < '"100"' )
          * )
          */
-        s.append(" CASE jsonb_typeof(").append(vals.indexJson).append(")")
-        .append(" WHEN 'number' then (").append(vals.indexText).append(")::numeric ").append(numberMatch)
-        .append(" ELSE ").append(vals.indexText).append(match)
-        .append(" END");
+        append(s,
+            "((",
+            "jsonb_typeof(", vals.indexJson, ")='number'",
+            " AND ", vals.indexJson, numberMatch.replace("\"", ""),
+            ") OR (",
+            "jsonb_typeof(", vals.indexJson, ")<>'number'",
+            " AND ", vals.indexJson, numberMatch,
+            "))");
       }
     }
     if (matches.length <= 1) {

--- a/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -1,5 +1,6 @@
 package org.z3950.zing.cql.cql2pgjson;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.z3950.zing.cql.CQLRelation;
@@ -508,6 +509,28 @@ public class CQL2PgJSONTest {
   })
   public void unicodeCaseAccents(String testcase) {
     select(testcase);
+  }
+
+  @Test
+  @Parameters({
+    "address.city==/respectCase/respectAccents S*      # Jo Jane; Lea Long",
+    "address.city<>/respectCase/respectAccents S*      # Ka Keller",
+    "address.city==/respectCase/respectAccents S*g     # Lea Long",
+    "address.city<>/respectCase/respectAccents S*g     # Jo Jane; Ka Keller",
+    "address.city==/respectCase/respectAccents Sø*     # Lea Long",
+    "address.city==/respectCase/respectAccents Sø*g    # Lea Long",
+    "address.city==/respectCase/respectAccents ?øvang  # Lea Long",
+    "address.city==/respectCase/respectAccents S?vang  # Lea Long",
+    "address.city==/respectCase/respectAccents Søvan?  # Lea Long",
+    "address.city==/respectCase/respectAccents *Søvang # Lea Long",
+    "address.city==/respectCase/respectAccents **v**   # Jo Jane; Lea Long",
+    "address.city==/respectCase/respectAccents **?y?** # Jo Jane",
+    "address.city==/respectCase/respectAccents søvang  #",         // lowercase
+  })
+  public void like(String testcase) throws QueryValidationException {
+    select(testcase);
+    String sql = cql2pgJson.cql2pgJson(testcase.substring(0, testcase.indexOf('#')));
+    assertThat(sql, containsString(" LIKE "));
   }
 
   @Test


### PR DESCRIPTION
* LIKE is only possible if each characters has no
  case or accent/diacritic possibilities.
  See CQLPG-10 using unaccent() for the full solution.
* fix sonar and checkstyle issues
* add javadoc