### PR TITLE
Release 2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 2.0.0 2018-01-09
+ * CQLPG-32: The default relation = now uses "adj" relation for strings (was "all").
+ * CQLPG-23: Support "any" relation.
+ * CQLPG-33: Performance test for number match.
+
 ## 1.3.4 2018-01-05
  * CQLPG-31: CQL number match when invoked without schema
  * CQLPG-30: Trigger on postgres numbers, not only on json numbers

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.z3950.zing</groupId>
   <artifactId>cql2pgjson</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>cql2pgjson</name>
 
   <prerequisites>
@@ -163,7 +163,7 @@
     <url>https://github.com/folio-org/cql2pgjson</url>
     <connection>scm:git:git://github.com/folio-org/cql2pgjson.git</connection>
     <developerConnection>scm:git:git@github.com/folio-org/cql2pgjson.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.z3950.zing</groupId>
   <artifactId>cql2pgjson</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.5-SNAPSHOT</version>
+  <version>2.0.0</version>
   <name>cql2pgjson</name>
 
   <prerequisites>
@@ -163,7 +163,7 @@
     <url>https://github.com/folio-org/cql2pgjson</url>
     <connection>scm:git:git://github.com/folio-org/cql2pgjson.git</connection>
     <developerConnection>scm:git:git@github.com/folio-org/cql2pgjson.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
 * CQLPG-32: The default relation = now uses "adj" relation for strings (was "all").
* CQLPG-23: Support "any" relation.
* CQLPG-33: Performance test for number match.