### PR TITLE
fix cqlpg-54-simple: Use 'simple' dictionary in to_tsvector 

### DIFF
--- a/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -1087,8 +1087,8 @@ public class CQL2PgJSON {
       }
       logger.log(Level.FINE, "pgFT(): term={0} ts={1}",
         new Object[]{node.getTerm(), tsTerm});
-      return "to_tsvector('english', " + fld + ") "
-        + "@@ to_tsquery('english','" + tsTerm + "')";
+      return "to_tsvector('simple', " + fld + ") "
+        + "@@ to_tsquery('simple','" + tsTerm + "')";
     } else {
       return pgFtNonTs(index, node, comparator, fld);
     }

--- a/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -357,8 +357,10 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "name=='   OR address.zip=1     # a",
     "name==\\  OR address.zip=1     # a",
     "h                              # h",
-    "a                              # ", // 'a' is a stop word, tokenized away
-    "\\a                            # ",
+    //"a                              # ", // 'a' is a stop word, tokenized away, when using 'english'
+    //"\\a                            # ",
+    "a                              # a", // but not when using 'simple'
+    "\\a                            # a",
     "\\h                            # h"
   })
   public void special(String testcase) {


### PR DESCRIPTION
instead of 'english', to get around the stopwords