### PR TITLE
CQLPG-69: Update all used libraries to latest stable version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,19 +38,19 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.6</version>
+      <version>3.8.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.2</version>
+      <version>2.9.7</version>
     </dependency>
 
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20180130</version>
+      <version>20180813</version>
     </dependency>
 
     <dependency>
@@ -78,20 +78,20 @@
     <dependency>
       <groupId>ru.yandex.qatools.embed</groupId>
       <artifactId>postgresql-embedded</artifactId>
-      <version>2.5</version>
+      <version>2.9</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.1.4</version>
+      <version>42.2.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
       <type>jar</type>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This also fixes security vulnerabilities in that libraries,
including, but not limited to:

* jackson-databind:
    * https://www.cvedetails.com/cve/CVE-2017-17485/
    * https://www.cvedetails.com/cve/CVE-2018-5968/
    * https://www.cvedetails.com/cve/CVE-2018-7489/
* PostgreSQL (vis embedded-postgresql):
    * CVE-2017-12172: Start scripts permit database administrator to modify root-owned files
    * CVE-2017-15098: Memory disclosure in JSON functions
    * CVE-2017-15099: INSERT ... ON CONFLICT DO UPDATE fails to enforce SELECT privileges
    * CVE-2018-1052: Fix the processing of partition keys containing multiple expressions
    * CVE-2018-1053: Ensure that all temporary files made with "pg_upgrade" are non-world-readable
    * CVE-2018-1058: Uncontrolled search path element in pg_dump and other client applications
* PostgreSQL JDBC Driver
    * CVE-2018-10936: added server hostname verification for non-default SSL factories in sslmode=verify-full