### PR TITLE
CQLPG-76: Update jackson-databind to 2.9.8 fixing security vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.7</version>
+      <version>2.9.8</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fixes
* https://nvd.nist.gov/vuln/detail/CVE-2018-19360
* https://nvd.nist.gov/vuln/detail/CVE-2018-19361
* https://nvd.nist.gov/vuln/detail/CVE-2018-19362
* https://nvd.nist.gov/vuln/detail/CVE-2018-1000873