### PR TITLE
Cqlpg 89 sort by id should directly use primary key 

### DIFF
--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -474,7 +474,16 @@ public class CQL2PgJSON {
       }  // ASC not needed, it's Postgres' default
 
       IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
-
+      //determine if sort is primary key 
+      String pkColumnName = dbTable.optString("pkColumnName", /* default = */ "id");
+      String pkColumnComparator = pkColumnName;
+      if(pkColumnComparator.equals( "_id")) {
+        pkColumnComparator = "id";
+      }
+      if(pkColumnComparator.equals( modifierSet.getBase())) {
+        //if it is we short circuit the json and just use the pkColumnName 
+        vals.indexJson = pkColumnName;
+      }
       // if number sort is specified explicitly
       if (modifiers.cqlSortType == CqlSortType.NUMBER) {
         order.append(vals.indexJson).append(desc);

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -477,23 +477,23 @@ public class CQL2PgJSON {
       String sortbyClauseText  = wrapInLowerUnaccent(vals.indexText);
       String sortByClauseIndex = vals.indexJson;
       //determine if sort is primary key 
-      if(dbTable != null) {
-        String pkColumnName = getPkColumnName();
-        String pkColumnComparator = pkColumnName;
-        String actualModifierBase = modifierSet.getBase();
-        //_id is actually referred to as id by cql so we need to check for the known cql value
+      
+      String pkColumnName = getPkColumnName();
+      String pkColumnComparator = pkColumnName;
+      String actualModifierBase = modifierSet.getBase();
+      //_id is actually referred to as id by cql so we need to check for the known cql value
 
-        if(actualModifierBase.equals("id")) {
-          actualModifierBase = pkColumnName;
-        }
-        if(pkColumnComparator.equals(actualModifierBase)) {
-          //if it is we short circuit the json version of the column and just use the pkColumnName 
-          sortbyClauseText =  pkColumnName;
-          sortByClauseIndex = pkColumnName;
-        } else {
-          
-        }
+      if(actualModifierBase.equals("id")) {
+        actualModifierBase = pkColumnName;
       }
+      if(pkColumnComparator.equals(actualModifierBase)) {
+        //if it is we short circuit the json version of the column and just use the pkColumnName 
+        sortbyClauseText =  pkColumnName;
+        sortByClauseIndex = pkColumnName;
+      } else {
+        //left blank due to default assignment handling this case 
+      }
+      
       // if number sort is specified explicitly
       if (modifiers.cqlSortType == CqlSortType.NUMBER) {
         order.append(sortByClauseIndex).append(desc);
@@ -516,8 +516,10 @@ public class CQL2PgJSON {
   }
 
   private String getPkColumnName() {
-    String pkColumnName = dbTable.optString("pkColumnName", /* default = */ "id");
-    return pkColumnName;
+    if(dbTable != null) {
+      return dbTable.optString("pkColumnName", /* default = */ "id");
+    }
+    return null;
   }
 
   private static String sqlOperator(CQLBooleanNode node) throws CQLFeatureUnsupportedException {

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -486,7 +486,7 @@ public class CQL2PgJSON {
       if(actualModifierBase.equals("id")) {
         actualModifierBase = pkColumnName;
       }
-      if(pkColumnComparator.equals(actualModifierBase)) {
+      if(pkColumnComparator != null && pkColumnComparator.equals(actualModifierBase)) {
         //if it is we short circuit the json version of the column and just use the pkColumnName 
         sortbyClauseText =  pkColumnName;
         sortByClauseIndex = pkColumnName;

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -472,18 +472,22 @@ public class CQL2PgJSON {
       if (modifiers.cqlSort == CqlSort.DESCENDING) {
         desc = " DESC";
       }  // ASC not needed, it's Postgres' default
-
+      
       IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
+      String sortbyClause  = wrapInLowerUnaccent(vals.indexText);
       //determine if sort is primary key 
       if(dbTable != null) {
         String pkColumnName = dbTable.optString("pkColumnName", /* default = */ "id");
         String pkColumnComparator = pkColumnName;
+        
         if(pkColumnComparator.equals( "_id")) {
           pkColumnComparator = "id";
         }
         if(pkColumnComparator.equals( modifierSet.getBase())) {
           //if it is we short circuit the json and just use the pkColumnName 
-          vals.indexJson = pkColumnName;
+          sortbyClause =  pkColumnName;
+        } else {
+          
         }
       }
       // if number sort is specified explicitly
@@ -502,7 +506,7 @@ public class CQL2PgJSON {
       }
 
       // We assume that a CREATE INDEX for this has been installed.
-      order.append(wrapInLowerUnaccent(vals.indexText)).append(desc);
+      order.append(sortbyClause).append(desc);
     }
     return new SqlSelect(where, order.toString());
   }

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -475,14 +475,16 @@ public class CQL2PgJSON {
 
       IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
       //determine if sort is primary key 
-      String pkColumnName = dbTable.optString("pkColumnName", /* default = */ "id");
-      String pkColumnComparator = pkColumnName;
-      if(pkColumnComparator.equals( "_id")) {
-        pkColumnComparator = "id";
-      }
-      if(pkColumnComparator.equals( modifierSet.getBase())) {
-        //if it is we short circuit the json and just use the pkColumnName 
-        vals.indexJson = pkColumnName;
+      if(dbTable != null) {
+        String pkColumnName = dbTable.optString("pkColumnName", /* default = */ "id");
+        String pkColumnComparator = pkColumnName;
+        if(pkColumnComparator.equals( "_id")) {
+          pkColumnComparator = "id";
+        }
+        if(pkColumnComparator.equals( modifierSet.getBase())) {
+          //if it is we short circuit the json and just use the pkColumnName 
+          vals.indexJson = pkColumnName;
+        }
       }
       // if number sort is specified explicitly
       if (modifiers.cqlSortType == CqlSortType.NUMBER) {

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -482,9 +482,7 @@ public class CQL2PgJSON {
         String pkColumnComparator = pkColumnName;
         String actualModifierBase = modifierSet.getBase();
         //_id is actually referred to as id by cql so we need to check for the known cql value
-        if(pkColumnComparator.equals( "_id")) {
-          pkColumnComparator = "id";
-        }
+
         if(actualModifierBase.equals("id")) {
           actualModifierBase = pkColumnName;
         }

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -90,7 +90,6 @@ public class CQL2PgJSON {
   }
 
   private static class IndexTextAndJsonValues {
-    String indexPure;
     String indexText;
     String indexJson;
     /** the RAML type like integer, number, string, boolean, datetime, ... "" for unknown. */
@@ -492,7 +491,7 @@ public class CQL2PgJSON {
       }
 
       // We assume that a CREATE INDEX for this has been installed.
-      order.append(vals.indexText).append(desc);
+      order.append(wrapInLowerUnaccent(vals.indexText)).append(desc);
     }
     return new SqlSelect(where, order.toString());
   }
@@ -769,7 +768,6 @@ public class CQL2PgJSON {
       finalIndex = field.getPath();
       vals.type = field.getType();
     }
-    vals.indexPure = finalIndex;
     vals.indexJson = index2sqlJson(this.jsonField, finalIndex);
     vals.indexText = index2sqlText(this.jsonField, finalIndex);
     return vals;

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -474,31 +474,37 @@ public class CQL2PgJSON {
       }  // ASC not needed, it's Postgres' default
       IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
       //prepare sort by clause as if the sort by is not the primary key
-      String sortbyClause  = wrapInLowerUnaccent(vals.indexText);
+      String sortbyClauseText  = wrapInLowerUnaccent(vals.indexText);
+      String sortByClauseIndex = vals.indexJson;
       //determine if sort is primary key 
       if(dbTable != null) {
         String pkColumnName = getPkColumnName();
         String pkColumnComparator = pkColumnName;
+        String actualModifierBase = modifierSet.getBase();
         //_id is actually referred to as id by cql so we need to check for the known cql value
         if(pkColumnComparator.equals( "_id")) {
           pkColumnComparator = "id";
         }
-        if(pkColumnComparator.equals( modifierSet.getBase())) {
+        if(actualModifierBase.equals("id")) {
+          actualModifierBase = pkColumnName;
+        }
+        if(pkColumnComparator.equals(actualModifierBase)) {
           //if it is we short circuit the json version of the column and just use the pkColumnName 
-          sortbyClause =  pkColumnName;
+          sortbyClauseText =  pkColumnName;
+          sortByClauseIndex = pkColumnName;
         } else {
           
         }
       }
       // if number sort is specified explicitly
       if (modifiers.cqlSortType == CqlSortType.NUMBER) {
-        order.append(vals.indexJson).append(desc);
+        order.append(sortByClauseIndex).append(desc);
         continue;
       } else {
         switch (vals.type) {
         case "number":
         case "integer":
-          order.append(vals.indexJson).append(desc);
+          order.append(sortByClauseIndex).append(desc);
           continue;
         default:
           break;
@@ -506,7 +512,7 @@ public class CQL2PgJSON {
       }
 
       // We assume that a CREATE INDEX for this has been installed.
-      order.append(sortbyClause).append(desc);
+      order.append(sortbyClauseText).append(desc);
     }
     return new SqlSelect(where, order.toString());
   }

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -519,7 +519,7 @@ public class CQL2PgJSON {
     if(dbTable != null) {
       return dbTable.optString("pkColumnName", /* default = */ "id");
     }
-    return null;
+    return "id";
   }
 
   private static String sqlOperator(CQLBooleanNode node) throws CQLFeatureUnsupportedException {

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -472,13 +472,13 @@ public class CQL2PgJSON {
       if (modifiers.cqlSort == CqlSort.DESCENDING) {
         desc = " DESC";
       }  // ASC not needed, it's Postgres' default
-      
+
       if (modifierSet.getBase().equals("id")) {
         order.append(getPkColumnName()).append(desc);
         continue;
       }
       IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
-      
+
       // if number sort is specified explicitly
       if (modifiers.cqlSortType == CqlSortType.NUMBER || "number".equals( vals.type) || "integer".equals(vals.type) ) {
         order.append(vals.indexJson).append(desc);

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -480,7 +480,7 @@ public class CQL2PgJSON {
       IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
 
       // if number sort is specified explicitly
-      if (modifiers.cqlSortType == CqlSortType.NUMBER || "number".equals( vals.type) || "integer".equals(vals.type) ) {
+      if (modifiers.cqlSortType == CqlSortType.NUMBER || "number".equals( vals.type) || "integer".equals(vals.type)) {
         order.append(vals.indexJson).append(desc);
         continue;
       }
@@ -491,8 +491,8 @@ public class CQL2PgJSON {
     return new SqlSelect(where, order.toString());
   }
 
-  private String getPkColumnName() {
-    if(dbTable != null) {
+  String getPkColumnName() {
+    if (dbTable != null) {
       return dbTable.optString("pkColumnName", /* default = */ "id");
     }
     return "id";

--- a/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSON.java
@@ -90,6 +90,7 @@ public class CQL2PgJSON {
   }
 
   private static class IndexTextAndJsonValues {
+    String indexPure;
     String indexText;
     String indexJson;
     /** the RAML type like integer, number, string, boolean, datetime, ... "" for unknown. */
@@ -491,7 +492,7 @@ public class CQL2PgJSON {
       }
 
       // We assume that a CREATE INDEX for this has been installed.
-      order.append(wrapInLowerUnaccent(vals.indexText)).append(desc);
+      order.append(vals.indexText).append(desc);
     }
     return new SqlSelect(where, order.toString());
   }
@@ -768,6 +769,7 @@ public class CQL2PgJSON {
       finalIndex = field.getPath();
       vals.type = field.getType();
     }
+    vals.indexPure = finalIndex;
     vals.indexJson = index2sqlJson(this.jsonField, finalIndex);
     vals.indexText = index2sqlText(this.jsonField, finalIndex);
     return vals;

--- a/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -727,12 +727,12 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   public void toSql() throws QueryValidationException {
     SqlSelect s = cql2pgJson.toSql("email=Long sortBy name/sort.descending");
     assertEquals("lower(f_unaccent(users.user_data->>'email')) ~", s.getWhere().substring(0, 46));
-    assertEquals("users.user_data->>'name' DESC", s.getOrderBy());
+    assertEquals("lower(f_unaccent(users.user_data->>'name')) DESC", s.getOrderBy());
     String sql = s.toString();
     assertTrue(sql.startsWith("WHERE "
       + "lower(f_unaccent(users.user_data->>'email')) ~"));
     assertTrue(sql.endsWith(" ORDER BY "
-      + "users.user_data->>'name' DESC"));
+      + "lower(f_unaccent(users.user_data->>'name')) DESC"));
   }
 
   @Test

--- a/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -727,12 +727,12 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   public void toSql() throws QueryValidationException {
     SqlSelect s = cql2pgJson.toSql("email=Long sortBy name/sort.descending");
     assertEquals("lower(f_unaccent(users.user_data->>'email')) ~", s.getWhere().substring(0, 46));
-    assertEquals("lower(f_unaccent(users.user_data->>'name')) DESC", s.getOrderBy());
+    assertEquals("users.user_data->>'name' DESC", s.getOrderBy());
     String sql = s.toString();
     assertTrue(sql.startsWith("WHERE "
       + "lower(f_unaccent(users.user_data->>'email')) ~"));
     assertTrue(sql.endsWith(" ORDER BY "
-      + "lower(f_unaccent(users.user_data->>'name')) DESC"));
+      + "users.user_data->>'name' DESC"));
   }
 
   @Test

--- a/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -556,6 +556,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   @Test
   @Parameters({
     "example   sortBy name                           # Jo Jane; Ka Keller; Lea Long",
+    "example   sortBy id                           # Jo Jane; Ka Keller; Lea Long",
     "example   sortBy name/sort.ascending            # Jo Jane; Ka Keller; Lea Long",
     "example   sortBy name/sort.ascending/sort.text  # Jo Jane; Ka Keller; Lea Long",
     "example   sortBy name/sort.descending           # Lea Long; Ka Keller; Jo Jane",

--- a/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -556,7 +556,9 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   @Test
   @Parameters({
     "example   sortBy name                           # Jo Jane; Ka Keller; Lea Long",
-    "example   sortBy id                           # Jo Jane; Ka Keller; Lea Long",
+    "example   sortBy id                             # Jo Jane; Ka Keller; Lea Long",
+    "example   sortBy id/sort.ascending              # Jo Jane; Ka Keller; Lea Long",
+    "example   sortBy id/sort.descending             # Lea Long; Ka Keller; Jo Jane",
     "example   sortBy name/sort.ascending            # Jo Jane; Ka Keller; Lea Long",
     "example   sortBy name/sort.ascending/sort.text  # Jo Jane; Ka Keller; Lea Long",
     "example   sortBy name/sort.descending           # Lea Long; Ka Keller; Jo Jane",
@@ -768,12 +770,17 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   }
 
   @Test
-  public void pKeyDefault() throws CQL2PgJSONException {
+  @Parameters({
+    "id=\"11111111-1111-1111-1111-111111111111\", WHERE _id='11111111-1111-1111-1111-111111111111'",
+    "cql.allRecords=1 sortBy id                 , WHERE true ORDER BY _id                         ",
+  })
+  public void pKeyDefault(String cql, String expectedSql) throws CQL2PgJSONException {
     CQL2PgJSON c = new CQL2PgJSON("users.user_data");
+    assertEquals(expectedSql, c.toSql(cql).toString());
     c.dbTable.remove("pkColumnName");
-    String sql = c.toSql("id=\"11111111-1111-1111-1111-111111111111\"").getWhere();
     // default pkColumnName is id without underscore
-    assertEquals("id='11111111-1111-1111-1111-111111111111'", sql);
+    String expectedSqlDefault = expectedSql.replace("_", "");
+    assertEquals(expectedSqlDefault, c.toSql(cql).toString());
   }
 
   @Test

--- a/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -1,6 +1,7 @@
 package org.z3950.zing.cql.cql2pgjson;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 
@@ -843,6 +844,12 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   })
   public void pKey(String testcase) {
     select(cql2pgJson, testcase);
+  }
+
+  @Test
+  public void getPkColumnNameNull() throws FieldException {
+    CQL2PgJSON aCql2pgJson = new CQL2PgJSON("not.existing");
+    assertThat(aCql2pgJson.getPkColumnName(), is("id"));
   }
 
   //

--- a/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/z3950/zing/cql/cql2pgjson/CQL2PgJSONTest.java
@@ -764,22 +764,25 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "id=\"22222222*\",                           (_id>='22222222-0000-0000-0000-000000000000' and "
                                                + "_id<='22222222-ffff-ffff-ffff-ffffffffffff')",
   })
-  public void pKeySql(String cql, String expectedSql) throws QueryValidationException {
+  public void pkColumnSql(String cql, String expectedSql) throws QueryValidationException {
     assertEquals(expectedSql, cql2pgJson.toSql(cql).getWhere());
     assertEquals(expectedSql, cql2pgJson.toSql(cql.replace("=", "==")).getWhere());
   }
 
   @Test
   @Parameters({
-    "id=\"11111111-1111-1111-1111-111111111111\", WHERE _id='11111111-1111-1111-1111-111111111111'",
-    "cql.allRecords=1 sortBy id                 , WHERE true ORDER BY _id                         ",
+    "id=\"11111111-1111-1111-1111-111111111111\", WHERE pk='11111111-1111-1111-1111-111111111111'",
+    "cql.allRecords=1 sortBy id                 , WHERE true ORDER BY pk                         ",
+    "cql.allRecords=1 sortBy id/sort.number     , WHERE true ORDER BY pk                         ",
+    "cql.allRecords=1 sortBy id/sort.descending , WHERE true ORDER BY pk DESC                    ",
   })
-  public void pKeyDefault(String cql, String expectedSql) throws CQL2PgJSONException {
+  public void pkColumnName(String cql, String expectedSql) throws CQL2PgJSONException {
     CQL2PgJSON c = new CQL2PgJSON("users.user_data");
+    c.dbTable.put("pkColumnName", "pk");
     assertEquals(expectedSql, c.toSql(cql).toString());
     c.dbTable.remove("pkColumnName");
     // default pkColumnName is id without underscore
-    String expectedSqlDefault = expectedSql.replace("_", "");
+    String expectedSqlDefault = expectedSql.replace("pk", "id");
     assertEquals(expectedSqlDefault, c.toSql(cql).toString());
   }
 


### PR DESCRIPTION
fairly simple and no frills direction of the sort by field to be the index if it matches the pkColumnName.  Added one unit test to test it out